### PR TITLE
Fix compatibility with native PyUSB `usb.core.Device.ctrl_transfer`

### DIFF
--- a/adafruit_usb_host_descriptors.py
+++ b/adafruit_usb_host_descriptors.py
@@ -73,22 +73,20 @@ def get_descriptor(device, desc_type, index, buf, language_id=0):
     # pylint: disable=invalid-name
     wValue = desc_type << 8 | index
     wIndex = language_id
-    result = device.ctrl_transfer(
+    device.ctrl_transfer(
         _REQ_RCPT_DEVICE | _REQ_TYPE_STANDARD | _DIR_IN,
         _REQ_GET_DESCRIPTOR,
         wValue,
         wIndex,
         buf,
     )
-    if isinstance(result, array.array):
-        buf[:] = result.tobytes()
 
 
 def get_device_descriptor(device):
     """Fetch the device descriptor and return it."""
-    buf = bytearray(1)
+    buf = array.array("B", bytearray(1))
     get_descriptor(device, DESC_DEVICE, 0, buf)
-    full_buf = bytearray(buf[0])
+    full_buf = array.array("B", bytearray(buf[0]))
     get_descriptor(device, DESC_DEVICE, 0, full_buf)
     return full_buf
 
@@ -97,10 +95,10 @@ def get_configuration_descriptor(device, index):
     """Fetch the configuration descriptor, its associated descriptors and return it."""
     # Allow capitalization that matches the USB spec.
     # pylint: disable=invalid-name
-    buf = bytearray(4)
+    buf = array.array("B", bytearray(4))
     get_descriptor(device, DESC_CONFIGURATION, index, buf)
     wTotalLength = struct.unpack("<xxH", buf)[0]
-    full_buf = bytearray(wTotalLength)
+    full_buf = array.array("B", bytearray(wTotalLength))
     get_descriptor(device, DESC_CONFIGURATION, index, full_buf)
     return full_buf
 
@@ -113,19 +111,17 @@ def get_report_descriptor(device, interface_num, length):
     if length < 1:
         return None
 
-    buf = bytearray(length)
+    buf = array.array("B", bytearray(length))
     try:
         # 0x81 = Dir: IN | Type: Standard | Recipient: Interface
         # wValue = 0x2200 (Report Descriptor)
-        result = device.ctrl_transfer(
+        device.ctrl_transfer(
             _RECIP_INTERFACE | _REQ_TYPE_STANDARD | _DIR_IN,
             _REQ_GET_DESCRIPTOR,
             DESC_REPORT << 8,
             interface_num,
             buf,
         )
-        if isinstance(result, array.array):
-            buf[:] = result.tobytes()
         return buf
     except usb.core.USBError as e:
         print(f"Failed to read Report Descriptor: {e}")

--- a/adafruit_usb_host_descriptors.py
+++ b/adafruit_usb_host_descriptors.py
@@ -10,6 +10,7 @@ Helpers for getting USB descriptors
 * Author(s): Scott Shawcroft
 """
 
+import array
 import struct
 
 import usb
@@ -72,13 +73,15 @@ def get_descriptor(device, desc_type, index, buf, language_id=0):
     # pylint: disable=invalid-name
     wValue = desc_type << 8 | index
     wIndex = language_id
-    device.ctrl_transfer(
+    result = device.ctrl_transfer(
         _REQ_RCPT_DEVICE | _REQ_TYPE_STANDARD | _DIR_IN,
         _REQ_GET_DESCRIPTOR,
         wValue,
         wIndex,
         buf,
     )
+    if isinstance(result, array.array):
+        buf[:] = result.tobytes()
 
 
 def get_device_descriptor(device):
@@ -114,13 +117,15 @@ def get_report_descriptor(device, interface_num, length):
     try:
         # 0x81 = Dir: IN | Type: Standard | Recipient: Interface
         # wValue = 0x2200 (Report Descriptor)
-        device.ctrl_transfer(
+        result = device.ctrl_transfer(
             _RECIP_INTERFACE | _REQ_TYPE_STANDARD | _DIR_IN,
             _REQ_GET_DESCRIPTOR,
             DESC_REPORT << 8,
             interface_num,
             buf,
         )
+        if isinstance(result, array.array):
+            buf[:] = result.tobytes()
         return buf
     except usb.core.USBError as e:
         print(f"Failed to read Report Descriptor: {e}")

--- a/adafruit_usb_host_descriptors.py
+++ b/adafruit_usb_host_descriptors.py
@@ -88,7 +88,7 @@ def get_device_descriptor(device):
     get_descriptor(device, DESC_DEVICE, 0, buf)
     full_buf = array.array("B", bytearray(buf[0]))
     get_descriptor(device, DESC_DEVICE, 0, full_buf)
-    return full_buf
+    return bytearray(full_buf)
 
 
 def get_configuration_descriptor(device, index):
@@ -100,7 +100,7 @@ def get_configuration_descriptor(device, index):
     wTotalLength = struct.unpack("<xxH", buf)[0]
     full_buf = array.array("B", bytearray(wTotalLength))
     get_descriptor(device, DESC_CONFIGURATION, index, full_buf)
-    return full_buf
+    return bytearray(full_buf)
 
 
 def get_report_descriptor(device, interface_num, length):
@@ -122,7 +122,7 @@ def get_report_descriptor(device, interface_num, length):
             interface_num,
             buf,
         )
-        return buf
+        return bytearray(buf)
     except usb.core.USBError as e:
         print(f"Failed to read Report Descriptor: {e}")
         return None


### PR DESCRIPTION
This update accounts for the difference in the implementation of `usb.core.Device.ctrl_transfer` between native PyUSB and CircuitPython. Tested on MacOS with Python 3.14 and Adafruit Fruit Jam with CircuitPython 10.

Related to https://github.com/adafruit/Adafruit_CircuitPython_USB_Host_Mouse/issues/18